### PR TITLE
Update unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ module.exports = {
         "no-unused-vars": [
             "error",
             {
-                "args": "all"
+                "vars": "all",
+                "args": "after-used"
             }
         ],
         "no-useless-call": "error",


### PR DESCRIPTION
When using functions from API or libraries we do not control, we might have parameters, that are required, but we don't need to perform what we want.

This rule will allow us to leave a param unused if following params are used.